### PR TITLE
fix LiteDB initialize error on macOS

### DIFF
--- a/RuiJi.Net.Cmd/Program.cs
+++ b/RuiJi.Net.Cmd/Program.cs
@@ -2,6 +2,7 @@
 using RuiJi.Net.Owin;
 using System;
 using System.Diagnostics;
+using System.Net.NetworkInformation;
 
 namespace RuiJi.Net.Cmd
 {
@@ -9,6 +10,21 @@ namespace RuiJi.Net.Cmd
     {
         static void Main(string[] args)
         {
+//            
+//            foreach (NetworkInterface netInterface in NetworkInterface.GetAllNetworkInterfaces())
+//            {
+//                Console.WriteLine("Name: " + netInterface.Name);
+//                Console.WriteLine("Description: " + netInterface.Description);
+//                Console.WriteLine("Addresses: ");
+//                IPInterfaceProperties ipProps = netInterface.GetIPProperties();
+//                foreach (UnicastIPAddressInformation addr in ipProps.UnicastAddresses)
+//                {
+//                    Console.WriteLine(" " + addr.Address.ToString());
+//                }
+//                Console.WriteLine("");
+//            }
+            
+            
             Logger.GetLogger("").Info("Program started!");
 
             ServerManager.StartServers();

--- a/RuiJi.Net.Core/Utils/IPHelper.cs
+++ b/RuiJi.Net.Core/Utils/IPHelper.cs
@@ -23,7 +23,9 @@ namespace RuiJi.Net.Core.Utils
         public static IPAddress[] GetHostIPAddress()
         {
             var ips = Dns.GetHostEntry(Dns.GetHostName()).AddressList.ToList();
-            ips.RemoveAll(m => m.AddressFamily != AddressFamily.InterNetwork || m.ToString() == "127.0.0.1" || m.ToString() == "0.0.0.0");
+            ips.RemoveAll(m => m.AddressFamily != AddressFamily.InterNetwork 
+                             //  || m.ToString() == "127.0.0.1"
+                             || m.ToString() == "0.0.0.0");
 
             return (from m in ips
                     orderby m.ToString()

--- a/RuiJi.Net.Node/Feed/Db/ContentLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/ContentLiteDb.cs
@@ -6,11 +6,14 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Linq.Expressions;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
     public class ContentLiteDb
     {
+        private static readonly string connectionString = LiteDbStorageHelper.GetConnectionString(@"LiteDb/Proxys.db");
+
         static ContentLiteDb()
         {
             var path = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "LiteDb", "Content");
@@ -20,7 +23,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static List<ContentModel> GetModels(Paging page, string shard, int feedID = 0)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Content/" + shard + ".db"))
+            using (var db = new LiteDatabase(LiteDbStorageHelper.GetConnectionString(@"LiteDb/Content/" + shard + ".db")))
             {
                 var col = db.GetCollection<ContentModel>("contents");
 
@@ -37,7 +40,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool Remove(int[] ids, string shard)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Content/" + shard + ".db"))
+            using (var db = new LiteDatabase(LiteDbStorageHelper.GetConnectionString(@"LiteDb/Content/" + shard + ".db")))
             {
                 var col = db.GetCollection<ContentModel>("contents");
 

--- a/RuiJi.Net.Node/Feed/Db/FeedLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/FeedLiteDb.cs
@@ -5,29 +5,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Runtime.InteropServices;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
     public class FeedLiteDb
     {
-        /**
-         * System.TypeInitializationException: The type initializer for 'RuiJi.Net.Node.Feed.Db.FeedLiteDb' threw an exception. --->
-         * System.InvalidOperationException:
-         * Your platform does not support FileStream.Lock. Please set mode=Exclusive in your connnection string to avoid this error. ---> System.PlatformNotSupportedException: Locking/unlocking file regions is not supported on this platform. Use FileShare on the entire file instead.
-         *
-         * fix:
-         * OS X do not support file lock, so you can't use LiteDB with lock support (no multi process access). But you can still use LiteDB in multi thread model, using: "Mode=Exclusive" in connection string (exclusive mode do not lock file because open file in exclusive mode
-         * https://github.com/mbdavid/LiteDB/issues/787
-         * 
-         */
-        static readonly bool isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
-
-        /// <summary>
-        /// 
-        /// </summary>
-        static readonly string connectionString = 
-            isOSX ? @"Filename=LiteDb/Feeds.db;Mode=Exclusive"
-                : @"LiteDb/Feeds.db";
+        private static readonly string connectionString = LiteDbStorageHelper.GetConnectionString(@"LiteDb/Feeds.db");
         
         static FeedLiteDb()
         {

--- a/RuiJi.Net.Node/Feed/Db/FeedLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/FeedLiteDb.cs
@@ -150,7 +150,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void CreateIndex()
         {
-            using (var db = new LiteDatabase(@"Filename=LiteDb/Feeds.db;Mode=Exclusive"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FeedModel>("feeds");
                 col.EnsureIndex(m => m.SiteName);

--- a/RuiJi.Net.Node/Feed/Db/FuncLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/FuncLiteDb.cs
@@ -6,11 +6,14 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
     public class FuncLiteDb
     {
+        private static readonly string connectionString = LiteDbStorageHelper.GetConnectionString(@"LiteDb/Funcs.db");
+
         static FuncLiteDb()
         {
             CreateIndex();
@@ -18,7 +21,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static List<FuncModel> GetModels(Paging page, string type = "")
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
                 Expression<Func<FuncModel, bool>> expression = x => true;
@@ -37,7 +40,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void AddOrUpdate(FuncModel rule)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
 
@@ -58,7 +61,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void Remove(int id)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
                 col.Delete(id);
@@ -67,7 +70,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool Remove(int[] ids)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
 
@@ -79,7 +82,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void CreateIndex()
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
                 col.EnsureIndex(m => m.Name);
@@ -88,7 +91,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static FuncModel Get(int id)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
 
@@ -98,7 +101,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static FuncModel Get(string name, FuncType funcType = FuncType.URLFUNCTION)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Funcs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<FuncModel>("funcs");
 

--- a/RuiJi.Net.Node/Feed/Db/ProxyLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/ProxyLiteDb.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
@@ -12,6 +13,8 @@ namespace RuiJi.Net.Node.Feed.Db
     {
         private static int start = 0;
         private static object _lck = new object();
+        
+        private static readonly string connectionString = LiteDbStorageHelper.GetConnectionString(@"LiteDb/Proxys.db");
 
         static ProxyLiteDb()
         {
@@ -20,7 +23,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static List<ProxyModel> GetModels(Paging page)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<ProxyModel>("proxys");
 
@@ -32,7 +35,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static List<ProxyModel> GetModels(int[] pages, int pageSize)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<ProxyModel>("proxys");
 
@@ -50,7 +53,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void AddOrUpdate(ProxyModel proxy)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 lock (_lck)
                 {
@@ -69,7 +72,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void Remove(int id)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 lock (_lck)
                 {
@@ -81,7 +84,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool Remove(int[] ids)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 lock (_lck)
                 {
@@ -98,7 +101,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool StatusChange(int[] ids, Status status)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<ProxyModel>("proxys");
                 var list = col.Find(i => ids.Contains(i.Id)).ToList();
@@ -114,7 +117,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void CreateIndex()
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<ProxyModel>("proxys");
                 col.EnsureIndex(m => m.Ip);
@@ -125,7 +128,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static ProxyModel Get(int id)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<ProxyModel>("proxys");
 
@@ -135,7 +138,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static ProxyModel Get(string scheme)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Proxys.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 lock (_lck)
                 {

--- a/RuiJi.Net.Node/Feed/Db/RuleLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/RuleLiteDb.cs
@@ -5,11 +5,14 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
     public class RuleLiteDb
     {
+        private static readonly string connectionString = LiteDbStorageHelper.GetConnectionString(@"LiteDb/Rules.db");
+
         static RuleLiteDb()
         {
             CreateIndex();
@@ -17,7 +20,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static List<RuleModel> GetModels(Paging page, string key = null, string type = null, string status = null)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
 
@@ -39,7 +42,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void AddOrUpdate(RuleModel rule)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
                 if (Uri.IsWellFormedUriString(rule.Url, UriKind.Absolute))
@@ -61,7 +64,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool Remove(int id)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
                 return col.Delete(id);
@@ -70,7 +73,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool Remove(int[] ids)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
 
@@ -82,7 +85,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool StatusChange(int[] ids, Status status)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
                 var list = col.Find(i => ids.Contains(i.Id)).ToList();
@@ -98,7 +101,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void CreateIndex()
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("feeds");
                 col.EnsureIndex(m => m.Domain);
@@ -110,7 +113,7 @@ namespace RuiJi.Net.Node.Feed.Db
             url = url.Trim().ToLower();
             var domain = new Uri(url).GetDomain();
 
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
                 var rules = col.Find(Query.Where("Domain", m => m.AsString == domain)).ToList();
@@ -125,7 +128,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static RuleModel Get(int id)
         {
-            using (var db = new LiteDatabase(@"LiteDb/Rules.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<RuleModel>("rules");
 

--- a/RuiJi.Net.Node/Feed/Db/UAGroupLiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/UAGroupLiteDb.cs
@@ -4,12 +4,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
     public class UAGroupLiteDb
     {
-        private static readonly string Db = @"LiteDb/UAs.db";
+        private static readonly string Db = LiteDbStorageHelper.GetConnectionString(@"LiteDb/UAs.db");
         private static readonly string COLLECTION = "uAGroups";
 
         public static List<UAGroupModel> GetModels()

--- a/RuiJi.Net.Node/Feed/Db/UALiteDb.cs
+++ b/RuiJi.Net.Node/Feed/Db/UALiteDb.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Linq.Expressions;
 using System.Text;
 using System.Threading.Tasks;
+using RuiJi.Net.Storage;
 
 namespace RuiJi.Net.Node.Feed.Db
 {
@@ -18,12 +19,14 @@ namespace RuiJi.Net.Node.Feed.Db
             CreateIndex();
         }
 
-        private static readonly string Db = @"LiteDb/UAs.db";
         private static readonly string COLLECTION = "uAs";
+        
+        private static readonly string connectionString = LiteDbStorageHelper.GetConnectionString(@"LiteDb/UAs.db");
+
 
         public static List<UAModel> GetModels(Paging page, int groupId)
         {
-            using (var db = new LiteDatabase(Db))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>(COLLECTION);
                 Expression<Func<UAModel, bool>> expression = x => true;
@@ -38,7 +41,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void AddOrUpdate(UAModel ua)
         {
-            using (var db = new LiteDatabase(Db))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>(COLLECTION);
 
@@ -58,7 +61,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool Remove(int[] ids)
         {
-            using (var db = new LiteDatabase(Db))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>(COLLECTION);
 
@@ -70,7 +73,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static bool RemoveByGorup(int groupId)
         {
-            using (var db = new LiteDatabase(Db))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>(COLLECTION);
 
@@ -82,7 +85,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static UAModel Get(int id)
         {
-            using (var db = new LiteDatabase(Db))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>(COLLECTION);
 
@@ -92,7 +95,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static string GetOne()
         {
-            using (var db = new LiteDatabase(@"LiteDb/UAs.db"))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>("uAs");
 
@@ -108,7 +111,7 @@ namespace RuiJi.Net.Node.Feed.Db
 
         public static void CreateIndex()
         {
-            using (var db = new LiteDatabase(Db))
+            using (var db = new LiteDatabase(connectionString))
             {
                 var col = db.GetCollection<UAModel>(COLLECTION);
                 col.EnsureIndex(m => m.GroupId);

--- a/RuiJi.Net.Storage/LiteDbStorageHelper.cs
+++ b/RuiJi.Net.Storage/LiteDbStorageHelper.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+
+namespace RuiJi.Net.Storage
+{
+    public class LiteDbStorageHelper
+    {
+        
+        /**
+       * System.TypeInitializationException: The type initializer for 'RuiJi.Net.Node.Feed.Db.FeedLiteDb' threw an exception. --->
+       * System.InvalidOperationException:
+       * Your platform does not support FileStream.Lock. Please set mode=Exclusive in your connnection string to avoid this error. ---> System.PlatformNotSupportedException: Locking/unlocking file regions is not supported on this platform. Use FileShare on the entire file instead.
+       *
+       * fix:
+       * OS X do not support file lock, so you can't use LiteDB with lock support (no multi process access). But you can still use LiteDB in multi thread model, using: "Mode=Exclusive" in connection string (exclusive mode do not lock file because open file in exclusive mode
+       * https://github.com/mbdavid/LiteDB/issues/787
+       * 
+       */
+        static readonly bool isOSX = RuntimeInformation.IsOSPlatform(OSPlatform.OSX);
+
+        public static string GetConnectionString(string dbPath)
+        {
+            return isOSX
+                ? $@"Filename={dbPath};Mode=Exclusive"
+                : dbPath;
+        }
+        
+    }
+}


### PR DESCRIPTION
OS X do not support file lock, so you can't use LiteDB with lock support (no multi process access). But you can still use LiteDB in multi thread model, using: "Mode=Exclusive" in connection string (exclusive mode do not lock file because open file in exclusive mode

https://github.com/mbdavid/LiteDB/issues/787
