### PR TITLE
add netstandard 2.0 target

### DIFF
--- a/RuiJi.Net.Core/RuiJi.Net.Core.csproj
+++ b/RuiJi.Net.Core/RuiJi.Net.Core.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
     <Version>1.1.8</Version>
     <Authors>zhupingqi</Authors>
     <Company>zhupingqi</Company>
@@ -16,6 +15,7 @@
     <FileVersion>1.1.8.0</FileVersion>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
+    <TargetFrameworks>netstandard2.0;netcoreapp2.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION


今天想在项目里用 Ruijit 的 dll，不过发现 nuget 上发布的是 .NET Core 版本，.NET Framework 项目无法引用。
我直接修改了 Ruijit.NET 源码的编译 target 试了下编译 target 里面直接添加"netstandard 2.0" 可以直接编译通过的，这样就 Core 和 Framework 两个都能用了。

https://github.com/zhupingqi/RuiJi.Net/issues/8

